### PR TITLE
Moving attention weighting to InvokeAI syntax

### DIFF
--- a/ui/media/js/image-modifiers.js
+++ b/ui/media/js/image-modifiers.js
@@ -129,7 +129,8 @@ function createModifierGroup(modifierGroup, initiallyExpanded, removeBy) {
 }
 
 function trimModifiers(tag) {
-    return tag.replace(/^\(+|\)+$/g, '').replace(/^\[+|\]+$/g, '')
+    // Remove trailing '-' and/or '+'
+    return tag.replace(/[-+]+$/, '');
 }
 
 async function loadModifiers() {


### PR DESCRIPTION
() and [] were actually ignored by the legacy parser, so moving the Ctrl+Wheel shortcut to the InvokeAI syntax of '+' and '-'.